### PR TITLE
Translate Swedish sensor names to English

### DIFF
--- a/custom_components/homevolt_local/sensor.py
+++ b/custom_components/homevolt_local/sensor.py
@@ -114,7 +114,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
     ),
     HomevoltSensorEntityDescription(
         key="power",
-        name="Homevolt effekt",
+        name="Homevolt Power",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement="W",
         icon="mdi:battery-sync-outline",
@@ -122,7 +122,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
     ),
     HomevoltSensorEntityDescription(
         key="energy_produced",
-        name="Homevolt energi producerat",
+        name="Homevolt Energy Produced",
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement="kWh",
@@ -131,7 +131,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
     ),
     HomevoltSensorEntityDescription(
         key="energy_consumed",
-        name="Homevolt energi konsumerat",
+        name="Homevolt Energy Consumed",
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement="kWh",


### PR DESCRIPTION
This pull request updates the `HomevoltSensorEntityDescription` class in the `custom_components/homevolt_local/sensor.py` file to standardize sensor names by changing them from Swedish to English for improved consistency and accessibility.

### Sensor name updates:

* Updated the name of the "power" sensor from "Homevolt effekt" to "Homevolt Power" (`[custom_components/homevolt_local/sensor.pyL117-R125](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943L117-R125)`).
* Updated the name of the "energy_produced" sensor from "Homevolt energi producerat" to "Homevolt Energy Produced" (`[custom_components/homevolt_local/sensor.pyL117-R125](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943L117-R125)`).
* Updated the name of the "energy_consumed" sensor from "Homevolt energi konsumerat" to "Homevolt Energy Consumed" (`[custom_components/homevolt_local/sensor.pyL134-R134](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943L134-R134)`).