### PR TITLE
Add state_class as MEASUREMENT for power sensors

### DIFF
--- a/custom_components/homevolt_local/sensor.py
+++ b/custom_components/homevolt_local/sensor.py
@@ -110,6 +110,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
     HomevoltSensorEntityDescription(
         key="total_soc",
         device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="%",
         value_fn=lambda data: float(data.aggregated.bms_data[BMS_DATA_INDEX_TOTAL].soc)
         / 100

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -171,6 +171,7 @@
       'attributes': dict({
         'device_class': 'battery',
         'friendly_name': 'System Battery',
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'state': 'unknown',


### PR DESCRIPTION
This pull request updates the `HomevoltSensorEntityDescription` definitions to explicitly set the `state_class` to `SensorStateClass.MEASUREMENT` for relevant sensor entities in `custom_components/homevolt_local/sensor.py`. This change ensures that the sensors are correctly recognized as measurement-type sensors in Home Assistant, which improves compatibility with features like statistics and long-term data storage. The associated test snapshots have also been updated to reflect this change.

**Sensor entity improvements:**

* Added `state_class=SensorStateClass.MEASUREMENT` to the `total_soc` sensor entity description to indicate it reports measurement data.
* Added `state_class=SensorStateClass.MEASUREMENT` to the `power` sensor entity description.
* Added `state_class=SensorStateClass.MEASUREMENT` to each dynamically created `ems_{idx + 1}_power` sensor entity.

**Test updates:**

* Updated test snapshots in `test_sensor.ambr` to include the new `state_class` attribute for the affected sensors, ensuring the tests reflect the new configuration. [[1]](diffhunk://#diff-81c8fa529f0d0a1aa655c1f6de1024a76b84eea8bea8a95338d531fbd3059238R139) [[2]](diffhunk://#diff-81c8fa529f0d0a1aa655c1f6de1024a76b84eea8bea8a95338d531fbd3059238R174) [[3]](diffhunk://#diff-81c8fa529f0d0a1aa655c1f6de1024a76b84eea8bea8a95338d531fbd3059238R225)