### PR TITLE
Add zip_release option to hacs.json configuration

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,5 @@
   "hacs": "2.0.5",
   "render_readme": true,
   "zip_release": true,
-  "filename": "homevolt_local"
+  "filename": "homevolt_local.zip"
 }


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `hacs.json` file. The change enables the creation of a zipped release for the integration.

- Configuration update:
  * Added the `"zip_release": true` option to `hacs.json` 
  
  
  This would resolve the v0.0.0 issue I hope