### PR TITLE
Remove ignored brands from HACS validation step

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -18,7 +18,6 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
-          ignore: "brands" # it't submitted but waiting for approval
 
   hassfest:
     name: 🏠 Hassfest


### PR DESCRIPTION
Should we go for hacs release? I see that tibber integration has also now battery sensor for homevolt 😨 

I'll fast track the support of actions for scheduling the homevolt 😄 