### PR TITLE
Refactor: integrate HomevoltEntity

### DIFF
--- a/custom_components/homevolt_local/entity.py
+++ b/custom_components/homevolt_local/entity.py
@@ -1,0 +1,297 @@
+"""The Homevolt Local integration base entity."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from .coordinator import HomevoltDataUpdateCoordinator
+    from .models import HomevoltData
+
+_LOGGER = logging.getLogger(__name__)
+
+MANUFACTURER = "Homevolt"
+
+
+class HomevoltEntity(CoordinatorEntity["HomevoltDataUpdateCoordinator"]):
+    """Base class for Homevolt entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HomevoltDataUpdateCoordinator,
+        ems_index: int | None = None,
+        sensor_index: int | None = None,
+        bms_index: int | None = None,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.ems_index = ems_index
+        self.sensor_index = sensor_index
+        self.bms_index = bms_index
+
+    @property
+    def main_device_id(self) -> str:
+        """Return the main device ID for consistent identification."""
+        return f"homevolt_{self.coordinator.get_main_device_id()}"
+
+    @property
+    def data(self) -> HomevoltData | None:
+        """Return the coordinator data."""
+        return self.coordinator.data
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this Homevolt device."""
+        main_device_id = self.main_device_id
+
+        # BMS (Battery) device - sub-device of the Inverter
+        if self.bms_index is not None and self.ems_index is not None:
+            return self._get_bms_device_info(main_device_id)
+        elif self.ems_index is not None:
+            return self._get_ems_device_info(main_device_id)
+        elif self.sensor_index is not None:
+            return self._get_sensor_device_info(main_device_id)
+        else:
+            return self._get_system_device_info(main_device_id)
+
+    def _get_bms_device_info(self, main_device_id: str) -> DeviceInfo:
+        """Return device info for a BMS (battery) device."""
+        if self.ems_index is None or self.bms_index is None:
+            return self._get_system_device_info(main_device_id)
+
+        if not self.coordinator.data or not self.coordinator.data.ems:
+            return self._get_fallback_bms_device_info(main_device_id)
+
+        ems_index = self.ems_index
+        bms_index = self.bms_index
+
+        try:
+            ems_device = self.coordinator.data.ems[ems_index]
+            ecu_id = ems_device.ecu_id or f"unknown_{ems_index}"
+            inverter_device_id = f"ems_{ecu_id}"
+
+            # Get BMS info for this battery
+            bms_info = (
+                ems_device.bms_info[bms_index]
+                if ems_device.bms_info and len(ems_device.bms_info) > bms_index
+                else None
+            )
+            bms_serial = (
+                bms_info.serial_number
+                if bms_info and bms_info.serial_number
+                else f"bms_{bms_index}"
+            )
+            bms_fw = bms_info.fw_version if bms_info else ""
+            bms_id = bms_info.id + 1 if bms_info else bms_index + 1
+            inverter_num = ems_index + 1
+
+            return DeviceInfo(
+                identifiers={(DOMAIN, f"bms_{ecu_id}_{bms_serial}")},
+                translation_key="battery",
+                translation_placeholders={
+                    "inverter_num": str(inverter_num),
+                    "battery_num": str(bms_id),
+                },
+                manufacturer=MANUFACTURER,
+                model="Battery Module",
+                entry_type=DeviceEntryType.SERVICE,
+                via_device=(DOMAIN, inverter_device_id),
+                sw_version=bms_fw,
+                hw_version=bms_serial,
+            )
+        except IndexError:
+            return self._get_fallback_bms_device_info(main_device_id)
+
+    def _get_fallback_bms_device_info(self, main_device_id: str) -> DeviceInfo:
+        """Return fallback device info for a BMS device."""
+        ems_index = self.ems_index if self.ems_index is not None else 0
+        bms_index = self.bms_index if self.bms_index is not None else 0
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"bms_unknown_{ems_index}_{bms_index}")},
+            translation_key="battery",
+            translation_placeholders={
+                "inverter_num": str(ems_index + 1),
+                "battery_num": str(bms_index + 1),
+            },
+            manufacturer=MANUFACTURER,
+            model="Battery Module",
+            entry_type=DeviceEntryType.SERVICE,
+            via_device=(DOMAIN, main_device_id),
+        )
+
+    def _get_ems_device_info(self, main_device_id: str) -> DeviceInfo:
+        """Return device info for an EMS (inverter) device."""
+        if self.ems_index is None:
+            return self._get_system_device_info(main_device_id)
+
+        if not self.coordinator.data or not self.coordinator.data.ems:
+            return self._get_fallback_ems_device_info(main_device_id)
+
+        ems_index = self.ems_index
+
+        try:
+            ems_device = self.coordinator.data.ems[ems_index]
+            ecu_id = ems_device.ecu_id or f"unknown_{ems_index}"
+            serial_number = (
+                ems_device.inv_info.serial_number if ems_device.inv_info else ""
+            )
+            fw_version = ems_device.ems_info.fw_version if ems_device.ems_info else ""
+
+            return DeviceInfo(
+                identifiers={(DOMAIN, f"ems_{ecu_id}")},
+                translation_key="inverter",
+                translation_placeholders={"inverter_num": str(ems_index + 1)},
+                manufacturer=MANUFACTURER,
+                model=f"Energy Management System {fw_version}",
+                entry_type=DeviceEntryType.SERVICE,
+                via_device=(DOMAIN, main_device_id),
+                sw_version=fw_version,
+                hw_version=serial_number,
+            )
+        except IndexError:
+            return self._get_fallback_ems_device_info(main_device_id)
+
+    def _get_fallback_ems_device_info(self, main_device_id: str) -> DeviceInfo:
+        """Return fallback device info for an EMS device."""
+        ems_index = self.ems_index if self.ems_index is not None else 0
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"ems_unknown_{ems_index}")},
+            translation_key="inverter",
+            translation_placeholders={"inverter_num": str(ems_index + 1)},
+            manufacturer=MANUFACTURER,
+            model="Energy Management System",
+            entry_type=DeviceEntryType.SERVICE,
+            via_device=(DOMAIN, main_device_id),
+        )
+
+    def _get_sensor_device_info(self, main_device_id: str) -> DeviceInfo:
+        """Return device info for a sensor device (grid, solar, load)."""
+        if self.sensor_index is None:
+            return self._get_system_device_info(main_device_id)
+
+        if not self.coordinator.data or not self.coordinator.data.sensors:
+            return self._get_fallback_sensor_device_info(main_device_id)
+
+        sensor_index = self.sensor_index
+
+        try:
+            sensor_data = self.coordinator.data.sensors[sensor_index]
+            sensor_type = sensor_data.type or "unknown"
+            node_id = sensor_data.node_id
+            euid = sensor_data.euid or "unknown"
+
+            sensor_type_name = sensor_type.capitalize()
+
+            # Map sensor type to translation key
+            translation_key_map = {
+                "grid": "grid",
+                "solar": "solar",
+                "load": "load",
+            }
+            device_translation_key = translation_key_map.get(sensor_type.lower())
+
+            if device_translation_key:
+                return DeviceInfo(
+                    identifiers={(DOMAIN, f"sensor_{euid}")},
+                    translation_key=device_translation_key,
+                    manufacturer=MANUFACTURER,
+                    model=f"{sensor_type_name} Sensor (Node {node_id})",
+                    entry_type=DeviceEntryType.SERVICE,
+                    via_device=(DOMAIN, main_device_id),
+                )
+            else:
+                return DeviceInfo(
+                    identifiers={(DOMAIN, f"sensor_{euid}")},
+                    name=sensor_type_name,
+                    manufacturer=MANUFACTURER,
+                    model=f"{sensor_type_name} Sensor (Node {node_id})",
+                    entry_type=DeviceEntryType.SERVICE,
+                    via_device=(DOMAIN, main_device_id),
+                )
+        except IndexError:
+            return self._get_fallback_sensor_device_info(main_device_id)
+
+    def _get_fallback_sensor_device_info(self, main_device_id: str) -> DeviceInfo:
+        """Return fallback device info for a sensor device."""
+        sensor_index = self.sensor_index if self.sensor_index is not None else 0
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"sensor_unknown_{sensor_index}")},
+            name=f"Sensor {sensor_index + 1}",
+            manufacturer=MANUFACTURER,
+            model="Sensor",
+            entry_type=DeviceEntryType.SERVICE,
+            via_device=(DOMAIN, main_device_id),
+        )
+
+    def _get_system_device_info(self, main_device_id: str) -> DeviceInfo:
+        """Return device info for the main system device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, main_device_id)},
+            translation_key="system",
+            manufacturer=MANUFACTURER,
+            model="Energy Management System",
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+
+class HomevoltBatteryEntity(HomevoltEntity):
+    """Base class for Homevolt battery (BMS) entities."""
+
+    def __init__(
+        self,
+        coordinator: HomevoltDataUpdateCoordinator,
+        ems_index: int,
+        bms_index: int,
+    ) -> None:
+        """Initialize the battery entity."""
+        super().__init__(
+            coordinator,
+            ems_index=ems_index,
+            sensor_index=None,
+            bms_index=bms_index,
+        )
+
+
+class HomevoltInverterEntity(HomevoltEntity):
+    """Base class for Homevolt inverter (EMS) entities."""
+
+    def __init__(
+        self,
+        coordinator: HomevoltDataUpdateCoordinator,
+        ems_index: int,
+    ) -> None:
+        """Initialize the inverter entity."""
+        super().__init__(
+            coordinator,
+            ems_index=ems_index,
+            sensor_index=None,
+            bms_index=None,
+        )
+
+
+class HomevoltSensorDeviceEntity(HomevoltEntity):
+    """Base class for Homevolt sensor device entities (grid, solar, load)."""
+
+    def __init__(
+        self,
+        coordinator: HomevoltDataUpdateCoordinator,
+        sensor_index: int,
+    ) -> None:
+        """Initialize the sensor device entity."""
+        super().__init__(
+            coordinator,
+            ems_index=None,
+            sensor_index=sensor_index,
+            bms_index=None,
+        )

--- a/custom_components/homevolt_local/sensor.py
+++ b/custom_components/homevolt_local/sensor.py
@@ -24,9 +24,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_AGGREGATED,
@@ -41,6 +39,7 @@ from .const import (
     SENSOR_TYPE_SOLAR,
 )
 from .coordinator import HomevoltDataUpdateCoordinator
+from .entity import HomevoltEntity
 from .models import HomevoltData
 
 _LOGGER = logging.getLogger(__name__)
@@ -304,6 +303,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:home-export-outline",
+        entity_registry_enabled_default=False,
         value_fn=lambda data: _normalize_energy_val(
             data.aggregated.ems_aggregate.exported_kwh
         ),
@@ -318,6 +318,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:home-import-outline",
+        entity_registry_enabled_default=False,
         value_fn=lambda data: _normalize_energy_val(
             data.aggregated.ems_aggregate.imported_kwh
         ),
@@ -393,6 +394,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:transmission-tower-import",
+        entity_registry_enabled_default=False,
         value_fn=lambda data: _normalize_energy_val(
             next(
                 (s.energy_imported for s in data.sensors if s.type == SENSOR_TYPE_GRID),
@@ -415,6 +417,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:transmission-tower-export",
+        entity_registry_enabled_default=False,
         value_fn=lambda data: _normalize_energy_val(
             next(
                 (s.energy_exported for s in data.sensors if s.type == SENSOR_TYPE_GRID),
@@ -434,7 +437,6 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         key="grid_rssi",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-        state_class=SensorStateClass.MEASUREMENT,
         icon_fn=lambda data: _rssi_icon_for_sensor(data, SENSOR_TYPE_GRID),
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: next(
@@ -448,7 +450,6 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         key="grid_pdr",
         translation_key="packet_delivery_rate",
         native_unit_of_measurement=PERCENTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:signal-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: next(
@@ -483,6 +484,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:solar-power-variant",
+        entity_registry_enabled_default=False,
         value_fn=lambda data: _normalize_energy_val(
             next(
                 (
@@ -513,6 +515,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:solar-power-variant-outline",
+        entity_registry_enabled_default=False,
         value_fn=lambda data: _normalize_energy_val(
             next(
                 (
@@ -540,7 +543,6 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         key="solar_rssi",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-        state_class=SensorStateClass.MEASUREMENT,
         icon_fn=lambda data: _rssi_icon_for_sensor(data, SENSOR_TYPE_SOLAR),
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: next(
@@ -554,7 +556,6 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         key="solar_pdr",
         translation_key="packet_delivery_rate",
         native_unit_of_measurement=PERCENTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:signal-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: next(
@@ -589,6 +590,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:home-import-outline",
+        entity_registry_enabled_default=False,
         value_fn=lambda data: _normalize_energy_val(
             next(
                 (s.energy_imported for s in data.sensors if s.type == SENSOR_TYPE_LOAD),
@@ -611,6 +613,7 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         icon="mdi:home-export-outline",
+        entity_registry_enabled_default=False,
         value_fn=lambda data: _normalize_energy_val(
             next(
                 (s.energy_exported for s in data.sensors if s.type == SENSOR_TYPE_LOAD),
@@ -629,10 +632,9 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
 )
 
 
-class HomevoltSensor(CoordinatorEntity[HomevoltDataUpdateCoordinator], SensorEntity):
+class HomevoltSensor(HomevoltEntity, SensorEntity):
     """Representation of a Homevolt sensor."""
 
-    _attr_has_entity_name = True
     entity_description: HomevoltSensorEntityDescription
 
     def __init__(
@@ -644,253 +646,82 @@ class HomevoltSensor(CoordinatorEntity[HomevoltDataUpdateCoordinator], SensorEnt
         bms_index: int | None = None,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
+        super().__init__(
+            coordinator,
+            ems_index=ems_index,
+            sensor_index=sensor_index,
+            bms_index=bms_index,
+        )
         self.entity_description = description
-        self.ems_index = ems_index
-        self.sensor_index = sensor_index
-        self.bms_index = bms_index
         self._extra_attributes: dict[str, Any] = {}
 
         # Create a unique ID based on the device properties if available
+        self._attr_unique_id = self._generate_unique_id(description.key)
+
+    def _generate_unique_id(self, key: str) -> str:
+        """Generate a unique ID for this sensor."""
+        coordinator = self.coordinator
+
         if (
-            bms_index is not None
-            and ems_index is not None
+            self.bms_index is not None
+            and self.ems_index is not None
             and coordinator.data
             and coordinator.data.ems
         ):
             # BMS (Battery) sensor - use ems ecu_id + bms serial for unique ID
             try:
-                ems_device = coordinator.data.ems[ems_index]
-                ecu_id = ems_device.ecu_id or f"unknown_{ems_index}"
-                bms_info = (
-                    ems_device.bms_info[bms_index] if ems_device.bms_info else None
-                )
-                bms_serial = (
-                    bms_info.serial_number
-                    if bms_info and bms_info.serial_number
-                    else f"bms_{bms_index}"
-                )
-                self._attr_unique_id = (
-                    f"{DOMAIN}_{description.key}_bms_{ecu_id}_{bms_serial}"
-                )
-            except IndexError:
-                self._attr_unique_id = (
-                    f"{DOMAIN}_{description.key}_bms_{ems_index}_{bms_index}"
-                )
-        elif ems_index is not None and coordinator.data and coordinator.data.ems:
-            try:
-                # Use the ecu_id for a consistent unique ID
-                # across different IP addresses
-                ems_device = coordinator.data.ems[ems_index]
-                ecu_id = ems_device.ecu_id or f"unknown_{ems_index}"
-                self._attr_unique_id = f"{DOMAIN}_{description.key}_ems_{ecu_id}"
-            except IndexError:
-                # Fallback to a generic unique ID if we can't get the ecu_id
-                self._attr_unique_id = f"{DOMAIN}_{description.key}_ems_{ems_index}"
-        elif sensor_index is not None and coordinator.data and coordinator.data.sensors:
-            try:
-                # Use the euid for a consistent unique ID across different IP addresses
-                sensor_data = coordinator.data.sensors[sensor_index]
-                euid = sensor_data.euid
-                # Check for null/default euid (all zeros = virtual sensor)
-                # For these, use main device ID + sensor type for uniqueness
-                if not euid or euid == "0000000000000000":
-                    main_id = self.coordinator.get_main_device_id()
-                    sensor_type = sensor_data.type
-                    if not sensor_type:
-                        # This is unexpected - virtual sensors should have a type
-                        # Log warning so users know about potential data issues
-                        _LOGGER.warning(
-                            "Sensor at index %s has null EUID but no type. "
-                            "This may cause entity migration issues. "
-                            "Using fallback unique ID.",
-                            sensor_index,
-                        )
-                        sensor_type = f"sensor_{sensor_index}"
-                    self._attr_unique_id = (
-                        f"{DOMAIN}_{description.key}_{main_id}_{sensor_type}"
-                    )
-                else:
-                    self._attr_unique_id = f"{DOMAIN}_{description.key}_sensor_{euid}"
-            except IndexError:
-                # Fallback to a generic unique ID if we can't get the euid
-                self._attr_unique_id = (
-                    f"{DOMAIN}_{description.key}_sensor_{sensor_index}"
-                )
-        else:
-            # For aggregated sensors, use the first ecu_id for a stable unique ID
-            # that doesn't change when IP changes
-            main_id = self.coordinator.get_main_device_id()
-            self._attr_unique_id = f"{DOMAIN}_{description.key}_{main_id}"
-
-        self._attr_device_info = self.device_info
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this Homevolt device."""
-        # Main aggregated device ID - use ecu_id for consistency across IP changes
-        main_device_id = f"homevolt_{self.coordinator.get_main_device_id()}"
-
-        # BMS (Battery) device - sub-device of the Inverter
-        if (
-            self.bms_index is not None
-            and self.ems_index is not None
-            and self.coordinator.data
-            and self.coordinator.data.ems
-        ):
-            try:
-                ems_device = self.coordinator.data.ems[self.ems_index]
+                ems_device = coordinator.data.ems[self.ems_index]
                 ecu_id = ems_device.ecu_id or f"unknown_{self.ems_index}"
-                inverter_device_id = f"ems_{ecu_id}"
-
-                # Get BMS info for this battery
                 bms_info = (
-                    ems_device.bms_info[self.bms_index]
-                    if ems_device.bms_info and len(ems_device.bms_info) > self.bms_index
-                    else None
+                    ems_device.bms_info[self.bms_index] if ems_device.bms_info else None
                 )
                 bms_serial = (
                     bms_info.serial_number
                     if bms_info and bms_info.serial_number
                     else f"bms_{self.bms_index}"
                 )
-                bms_fw = bms_info.fw_version if bms_info else ""
-                bms_id = bms_info.id + 1 if bms_info else self.bms_index + 1
-                inverter_num = self.ems_index + 1
-
-                return DeviceInfo(
-                    identifiers={(DOMAIN, f"bms_{ecu_id}_{bms_serial}")},
-                    translation_key="battery",
-                    translation_placeholders={
-                        "inverter_num": str(inverter_num),
-                        "battery_num": str(bms_id),
-                    },
-                    manufacturer="Homevolt",
-                    model="Battery Module",
-                    entry_type=DeviceEntryType.SERVICE,
-                    via_device=(DOMAIN, inverter_device_id),  # Link to Inverter
-                    sw_version=bms_fw,
-                    hw_version=bms_serial,
-                )
+                return f"{DOMAIN}_{key}_bms_{ecu_id}_{bms_serial}"
             except IndexError:
-                return DeviceInfo(
-                    identifiers={
-                        (DOMAIN, f"bms_unknown_{self.ems_index}_{self.bms_index}")
-                    },
-                    translation_key="battery",
-                    translation_placeholders={
-                        "inverter_num": str(self.ems_index + 1),
-                        "battery_num": str(self.bms_index + 1),
-                    },
-                    manufacturer="Homevolt",
-                    model="Battery Module",
-                    entry_type=DeviceEntryType.SERVICE,
-                    via_device=(DOMAIN, main_device_id),
-                )
-        elif (
-            self.ems_index is not None
-            and self.coordinator.data
-            and self.coordinator.data.ems
-        ):
-            # Get device-specific information from the ems data
+                return f"{DOMAIN}_{key}_bms_{self.ems_index}_{self.bms_index}"
+
+        elif self.ems_index is not None and coordinator.data and coordinator.data.ems:
             try:
-                ems_device = self.coordinator.data.ems[self.ems_index]
+                ems_device = coordinator.data.ems[self.ems_index]
                 ecu_id = ems_device.ecu_id or f"unknown_{self.ems_index}"
-                serial_number = (
-                    ems_device.inv_info.serial_number if ems_device.inv_info else ""
-                )
-
-                # Try to get more detailed information for the device name
-                fw_version = (
-                    ems_device.ems_info.fw_version if ems_device.ems_info else ""
-                )
-
-                # Use the ecu_id as the unique identifier, which should be consistent
-                # across different IP addresses for the same physical device
-                return DeviceInfo(
-                    identifiers={(DOMAIN, f"ems_{ecu_id}")},
-                    translation_key="inverter",
-                    translation_placeholders={"inverter_num": str(self.ems_index + 1)},
-                    manufacturer="Homevolt",
-                    model=f"Energy Management System {fw_version}",
-                    entry_type=DeviceEntryType.SERVICE,
-                    via_device=(DOMAIN, main_device_id),  # Link to the main device
-                    sw_version=fw_version,
-                    hw_version=serial_number,
-                )
+                return f"{DOMAIN}_{key}_ems_{ecu_id}"
             except IndexError:
-                # Fallback to a generic device info if we can't get specific info
-                return DeviceInfo(
-                    identifiers={(DOMAIN, f"ems_unknown_{self.ems_index}")},
-                    translation_key="inverter",
-                    translation_placeholders={"inverter_num": str(self.ems_index + 1)},
-                    manufacturer="Homevolt",
-                    model="Energy Management System",
-                    entry_type=DeviceEntryType.SERVICE,
-                    via_device=(DOMAIN, main_device_id),  # Link to the main device
-                )
+                return f"{DOMAIN}_{key}_ems_{self.ems_index}"
+
         elif (
             self.sensor_index is not None
-            and self.coordinator.data
-            and self.coordinator.data.sensors
+            and coordinator.data
+            and coordinator.data.sensors
         ):
-            # Get device-specific information from the sensors data
             try:
-                sensor_data = self.coordinator.data.sensors[self.sensor_index]
-                sensor_type = sensor_data.type or "unknown"
-                node_id = sensor_data.node_id
-                euid = sensor_data.euid or "unknown"
-
-                # Capitalize the first letter of the sensor type for the name
-                sensor_type_name = sensor_type.capitalize()
-
-                # Map sensor type to translation key
-                translation_key_map = {
-                    "grid": "grid",
-                    "solar": "solar",
-                    "load": "load",
-                }
-                device_translation_key = translation_key_map.get(sensor_type.lower())
-
-                # Use the euid as the unique identifier, which should be consistent
-                # across different IP addresses for the same physical sensor
-                if device_translation_key:
-                    return DeviceInfo(
-                        identifiers={(DOMAIN, f"sensor_{euid}")},
-                        translation_key=device_translation_key,
-                        manufacturer="Homevolt",
-                        model=f"{sensor_type_name} Sensor (Node {node_id})",
-                        entry_type=DeviceEntryType.SERVICE,
-                        via_device=(DOMAIN, main_device_id),  # Link to the main device
-                    )
+                sensor_data = coordinator.data.sensors[self.sensor_index]
+                euid = sensor_data.euid
+                # Check for null/default euid (all zeros = virtual sensor)
+                if not euid or euid == "0000000000000000":
+                    main_id = coordinator.get_main_device_id()
+                    sensor_type = sensor_data.type
+                    if not sensor_type:
+                        _LOGGER.warning(
+                            "Sensor at index %s has null EUID but no type. "
+                            "This may cause entity migration issues. "
+                            "Using fallback unique ID.",
+                            self.sensor_index,
+                        )
+                        sensor_type = f"sensor_{self.sensor_index}"
+                    return f"{DOMAIN}_{key}_{main_id}_{sensor_type}"
                 else:
-                    return DeviceInfo(
-                        identifiers={(DOMAIN, f"sensor_{euid}")},
-                        name=sensor_type_name,
-                        manufacturer="Homevolt",
-                        model=f"{sensor_type_name} Sensor (Node {node_id})",
-                        entry_type=DeviceEntryType.SERVICE,
-                        via_device=(DOMAIN, main_device_id),  # Link to the main device
-                    )
+                    return f"{DOMAIN}_{key}_sensor_{euid}"
             except IndexError:
-                # Fallback to a generic device info if we can't get specific info
-                return DeviceInfo(
-                    identifiers={(DOMAIN, f"sensor_unknown_{self.sensor_index}")},
-                    name=f"Sensor {self.sensor_index + 1}",
-                    manufacturer="Homevolt",
-                    model="Sensor",
-                    entry_type=DeviceEntryType.SERVICE,
-                    via_device=(DOMAIN, main_device_id),  # Link to the main device
-                )
+                return f"{DOMAIN}_{key}_sensor_{self.sensor_index}"
+
         else:
-            # For aggregated sensors or if no ems_index or sensor_index is provided
-            return DeviceInfo(
-                identifiers={(DOMAIN, main_device_id)},
-                translation_key="system",
-                manufacturer="Homevolt",
-                model="Energy Management System",
-                entry_type=DeviceEntryType.SERVICE,
-            )
+            # For aggregated sensors
+            main_id = coordinator.get_main_device_id()
+            return f"{DOMAIN}_{key}_{main_id}"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -1,31 +1,10 @@
 # serializer version: 1
 # name: test_sensor_states_snapshot
   dict({
-    'sensor.grid_energy_exported': dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Grid Energy exported',
-        'icon': 'mdi:transmission-tower-export',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-      }),
-      'state': 'unknown',
-    }),
-    'sensor.grid_energy_imported': dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'Grid Energy imported',
-        'icon': 'mdi:transmission-tower-import',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-      }),
-      'state': 'unknown',
-    }),
     'sensor.grid_packet_delivery_rate': dict({
       'attributes': dict({
         'friendly_name': 'Grid Packet delivery rate',
         'icon': 'mdi:signal-variant',
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
       'state': 'unknown',
@@ -44,7 +23,6 @@
       'attributes': dict({
         'device_class': 'signal_strength',
         'friendly_name': 'Grid Signal strength',
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'dBm',
       }),
       'state': 'unknown',
@@ -196,26 +174,6 @@
         'icon': 'mdi:battery-arrow-down',
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
         'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
-      }),
-      'state': 'unknown',
-    }),
-    'sensor.system_energy_exported': dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'System Energy exported',
-        'icon': 'mdi:home-export-outline',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-      }),
-      'state': 'unknown',
-    }),
-    'sensor.system_energy_imported': dict({
-      'attributes': dict({
-        'device_class': 'energy',
-        'friendly_name': 'System Energy imported',
-        'icon': 'mdi:home-import-outline',
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
       }),
       'state': 'unknown',
     }),

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,550 @@
+"""Tests for Homevolt Local entity base classes."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from homeassistant.helpers.device_registry import DeviceEntryType
+
+from custom_components.homevolt_local.const import DOMAIN
+from custom_components.homevolt_local.entity import (
+    MANUFACTURER,
+    HomevoltBatteryEntity,
+    HomevoltEntity,
+    HomevoltInverterEntity,
+    HomevoltSensorDeviceEntity,
+)
+from custom_components.homevolt_local.models import HomevoltData
+
+
+def create_mock_coordinator(
+    data: HomevoltData | None = None,
+    main_device_id: str = "test_device_123",
+) -> MagicMock:
+    """Create a mock coordinator with optional data."""
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.get_main_device_id.return_value = main_device_id
+    return coordinator
+
+
+def create_test_homevolt_data(
+    ems_count: int = 1,
+    bms_per_ems: int = 1,
+    sensor_count: int = 1,
+) -> HomevoltData:
+    """Create test HomevoltData with configurable device counts."""
+    ems_list = []
+    for i in range(ems_count):
+        bms_data_list = [
+            {"soc": 5000, "tmax": 25.0, "tmin": 20.0} for _ in range(bms_per_ems)
+        ]
+        bms_info_list = [
+            {
+                "fw_version": f"2.{j}.0",
+                "serial_number": f"BMS{i:02d}{j:02d}",
+                "rated_cap": 5000,
+                "id": j,
+            }
+            for j in range(bms_per_ems)
+        ]
+        ems_list.append(
+            {
+                "ecu_id": f"ecu_{i:03d}",
+                "ems_data": {
+                    "state_str": "idle",
+                    "soc_avg": 50.0,
+                    "power": 100.0,
+                    "energy_produced": 1000.0,
+                    "energy_consumed": 500.0,
+                },
+                "error_str": "",
+                "inv_info": {"serial_number": f"INV{i:03d}"},
+                "ems_info": {"fw_version": f"1.{i}.0", "rated_capacity": 10000},
+                "bms_data": bms_data_list,
+                "bms_info": bms_info_list,
+            }
+        )
+
+    sensors = []
+    sensor_types = ["grid", "solar", "load"]
+    for i in range(sensor_count):
+        sensor_type = sensor_types[i % len(sensor_types)]
+        sensors.append(
+            {
+                "euid": f"sensor_{i:03d}",
+                "type": sensor_type,
+                "total_power": 200.0,
+                "energy_imported": 2000.0,
+                "energy_exported": 1000.0,
+                "available": True,
+                "node_id": i,
+            }
+        )
+
+    return HomevoltData.from_dict(
+        {
+            "aggregated": {
+                "ems_data": {
+                    "state_str": "idle",
+                    "soc_avg": 50.0,
+                    "power": 100.0,
+                    "energy_produced": 1000.0,
+                    "energy_consumed": 500.0,
+                },
+                "error_str": "",
+                "bms_data": [{"soc": 5000, "tmax": 25.0, "tmin": 20.0}],
+            },
+            "ems": ems_list,
+            "sensors": sensors,
+        }
+    )
+
+
+class TestHomevoltEntity:
+    """Tests for the HomevoltEntity base class."""
+
+    def test_init_default_indices(self) -> None:
+        """Test entity initialization with default indices."""
+        coordinator = create_mock_coordinator()
+        entity = HomevoltEntity(coordinator)
+
+        assert entity.ems_index is None
+        assert entity.sensor_index is None
+        assert entity.bms_index is None
+        assert entity.coordinator is coordinator
+
+    def test_init_with_indices(self) -> None:
+        """Test entity initialization with specific indices."""
+        coordinator = create_mock_coordinator()
+        entity = HomevoltEntity(coordinator, ems_index=1, sensor_index=2, bms_index=3)
+
+        assert entity.ems_index == 1
+        assert entity.sensor_index == 2
+        assert entity.bms_index == 3
+
+    def test_main_device_id(self) -> None:
+        """Test main_device_id property."""
+        coordinator = create_mock_coordinator(main_device_id="my_device")
+        entity = HomevoltEntity(coordinator)
+
+        assert entity.main_device_id == "homevolt_my_device"
+
+    def test_data_property(self) -> None:
+        """Test data property returns coordinator data."""
+        data = create_test_homevolt_data()
+        coordinator = create_mock_coordinator(data=data)
+        entity = HomevoltEntity(coordinator)
+
+        assert entity.data is data
+
+    def test_data_property_none(self) -> None:
+        """Test data property when coordinator has no data."""
+        coordinator = create_mock_coordinator(data=None)
+        entity = HomevoltEntity(coordinator)
+
+        assert entity.data is None
+
+    def test_has_entity_name_attribute(self) -> None:
+        """Test entity has _attr_has_entity_name set."""
+        coordinator = create_mock_coordinator()
+        entity = HomevoltEntity(coordinator)
+
+        assert entity._attr_has_entity_name is True
+
+
+class TestHomevoltEntityDeviceInfo:
+    """Tests for HomevoltEntity device_info property."""
+
+    def test_system_device_info(self) -> None:
+        """Test device info for system-level entity (no indices)."""
+        coordinator = create_mock_coordinator(main_device_id="test_123")
+        entity = HomevoltEntity(coordinator)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "homevolt_test_123")}
+        assert device_info.get("translation_key") == "system"
+        assert device_info.get("manufacturer") == MANUFACTURER
+        assert device_info.get("model") == "Energy Management System"
+        assert device_info.get("entry_type") == DeviceEntryType.SERVICE
+
+    def test_ems_device_info_with_data(self) -> None:
+        """Test device info for EMS entity with coordinator data."""
+        data = create_test_homevolt_data(ems_count=1)
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, ems_index=0)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "ems_ecu_000")}
+        assert device_info.get("translation_key") == "inverter"
+        assert device_info.get("translation_placeholders") == {"inverter_num": "1"}
+        assert device_info.get("manufacturer") == MANUFACTURER
+        model = device_info.get("model")
+        assert model is not None and "1.0.0" in model
+        assert device_info.get("via_device") == (DOMAIN, "homevolt_test_123")
+        assert device_info.get("sw_version") == "1.0.0"
+        assert device_info.get("hw_version") == "INV000"
+
+    def test_ems_device_info_fallback_no_data(self) -> None:
+        """Test EMS device info falls back when no coordinator data."""
+        coordinator = create_mock_coordinator(data=None, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, ems_index=0)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "ems_unknown_0")}
+        assert device_info.get("translation_key") == "inverter"
+        assert device_info.get("translation_placeholders") == {"inverter_num": "1"}
+        assert device_info.get("via_device") == (DOMAIN, "homevolt_test_123")
+
+    def test_ems_device_info_index_out_of_range(self) -> None:
+        """Test EMS device info with out-of-range index falls back."""
+        data = create_test_homevolt_data(ems_count=1)
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, ems_index=5)  # Out of range
+
+        device_info = entity.device_info
+
+        # Should use fallback
+        assert device_info.get("identifiers") == {(DOMAIN, "ems_unknown_5")}
+
+    def test_bms_device_info_with_data(self) -> None:
+        """Test device info for BMS entity with coordinator data."""
+        data = create_test_homevolt_data(ems_count=1, bms_per_ems=2)
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, ems_index=0, bms_index=1)
+
+        device_info = entity.device_info
+
+        # BMS serial is BMS0001 (ems_index=0, bms_index=1)
+        assert device_info.get("identifiers") == {(DOMAIN, "bms_ecu_000_BMS0001")}
+        assert device_info.get("translation_key") == "battery"
+        assert device_info.get("translation_placeholders") == {
+            "inverter_num": "1",
+            "battery_num": "2",  # bms_index 1 has id=1, so bms_id = 2
+        }
+        assert device_info.get("manufacturer") == MANUFACTURER
+        assert device_info.get("model") == "Battery Module"
+        assert device_info.get("via_device") == (DOMAIN, "ems_ecu_000")
+        assert device_info.get("sw_version") == "2.1.0"
+        assert device_info.get("hw_version") == "BMS0001"
+
+    def test_bms_device_info_fallback_no_data(self) -> None:
+        """Test BMS device info falls back when no coordinator data."""
+        coordinator = create_mock_coordinator(data=None, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, ems_index=0, bms_index=1)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "bms_unknown_0_1")}
+        assert device_info.get("translation_key") == "battery"
+        assert device_info.get("translation_placeholders") == {
+            "inverter_num": "1",
+            "battery_num": "2",
+        }
+        assert device_info.get("via_device") == (DOMAIN, "homevolt_test_123")
+
+    def test_bms_device_info_bms_index_out_of_range(self) -> None:
+        """Test BMS device info with out-of-range bms_index falls back."""
+        data = create_test_homevolt_data(ems_count=1, bms_per_ems=1)
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, ems_index=0, bms_index=5)  # Out of range
+
+        device_info = entity.device_info
+
+        # Should still work but bms_info won't be available
+        assert "bms_" in str(device_info.get("identifiers"))
+
+    def test_sensor_device_info_grid(self) -> None:
+        """Test device info for grid sensor."""
+        data = create_test_homevolt_data(sensor_count=1)  # Creates grid sensor
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, sensor_index=0)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "sensor_sensor_000")}
+        assert device_info.get("translation_key") == "grid"
+        assert device_info.get("manufacturer") == MANUFACTURER
+        model = device_info.get("model")
+        assert model is not None and "Grid" in model
+        assert device_info.get("via_device") == (DOMAIN, "homevolt_test_123")
+
+    def test_sensor_device_info_solar(self) -> None:
+        """Test device info for solar sensor."""
+        data = create_test_homevolt_data(sensor_count=2)  # Creates grid, solar
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, sensor_index=1)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "sensor_sensor_001")}
+        assert device_info.get("translation_key") == "solar"
+        model = device_info.get("model")
+        assert model is not None and "Solar" in model
+
+    def test_sensor_device_info_load(self) -> None:
+        """Test device info for load sensor."""
+        data = create_test_homevolt_data(sensor_count=3)  # Creates grid, solar, load
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, sensor_index=2)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "sensor_sensor_002")}
+        assert device_info.get("translation_key") == "load"
+        model = device_info.get("model")
+        assert model is not None and "Load" in model
+
+    def test_sensor_device_info_fallback_no_data(self) -> None:
+        """Test sensor device info falls back when no coordinator data."""
+        coordinator = create_mock_coordinator(data=None, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, sensor_index=0)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "sensor_unknown_0")}
+        assert device_info.get("name") == "Sensor 1"
+        assert device_info.get("model") == "Sensor"
+        assert device_info.get("via_device") == (DOMAIN, "homevolt_test_123")
+
+    def test_sensor_device_info_unknown_type(self) -> None:
+        """Test sensor device info for unknown sensor type."""
+        # Manually create data with unknown sensor type
+        data = HomevoltData.from_dict(
+            {
+                "aggregated": {
+                    "ems_data": {
+                        "state_str": "idle",
+                        "soc_avg": 50.0,
+                        "power": 100.0,
+                    },
+                    "error_str": "",
+                    "bms_data": [],
+                },
+                "ems": [],
+                "sensors": [
+                    {
+                        "euid": "sensor_unknown",
+                        "type": "custom_type",
+                        "total_power": 100.0,
+                        "available": True,
+                        "node_id": 0,
+                    }
+                ],
+            }
+        )
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, sensor_index=0)
+
+        device_info = entity.device_info
+
+        # Should use name instead of translation_key
+        assert device_info.get("identifiers") == {(DOMAIN, "sensor_sensor_unknown")}
+        assert device_info.get("name") == "Custom_type"
+        assert device_info.get("translation_key") is None
+
+
+class TestHomevoltBatteryEntity:
+    """Tests for HomevoltBatteryEntity subclass."""
+
+    def test_init(self) -> None:
+        """Test battery entity initialization."""
+        coordinator = create_mock_coordinator()
+        entity = HomevoltBatteryEntity(coordinator, ems_index=1, bms_index=2)
+
+        assert entity.ems_index == 1
+        assert entity.bms_index == 2
+        assert entity.sensor_index is None
+
+    def test_device_info_returns_bms_info(self) -> None:
+        """Test battery entity returns BMS device info."""
+        data = create_test_homevolt_data(ems_count=2, bms_per_ems=3)
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltBatteryEntity(coordinator, ems_index=1, bms_index=2)
+
+        device_info = entity.device_info
+
+        # BMS serial is BMS0102 (ems_index=1, bms_index=2)
+        assert "bms_ecu_001" in str(device_info.get("identifiers"))
+        assert device_info.get("translation_key") == "battery"
+
+
+class TestHomevoltInverterEntity:
+    """Tests for HomevoltInverterEntity subclass."""
+
+    def test_init(self) -> None:
+        """Test inverter entity initialization."""
+        coordinator = create_mock_coordinator()
+        entity = HomevoltInverterEntity(coordinator, ems_index=2)
+
+        assert entity.ems_index == 2
+        assert entity.bms_index is None
+        assert entity.sensor_index is None
+
+    def test_device_info_returns_ems_info(self) -> None:
+        """Test inverter entity returns EMS device info."""
+        data = create_test_homevolt_data(ems_count=3)
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltInverterEntity(coordinator, ems_index=1)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "ems_ecu_001")}
+        assert device_info.get("translation_key") == "inverter"
+        assert device_info.get("translation_placeholders") == {"inverter_num": "2"}
+
+
+class TestHomevoltSensorDeviceEntity:
+    """Tests for HomevoltSensorDeviceEntity subclass."""
+
+    def test_init(self) -> None:
+        """Test sensor device entity initialization."""
+        coordinator = create_mock_coordinator()
+        entity = HomevoltSensorDeviceEntity(coordinator, sensor_index=3)
+
+        assert entity.sensor_index == 3
+        assert entity.ems_index is None
+        assert entity.bms_index is None
+
+    def test_device_info_returns_sensor_info(self) -> None:
+        """Test sensor device entity returns sensor device info."""
+        data = create_test_homevolt_data(sensor_count=4)
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltSensorDeviceEntity(coordinator, sensor_index=1)
+
+        device_info = entity.device_info
+
+        assert device_info.get("identifiers") == {(DOMAIN, "sensor_sensor_001")}
+        # sensor_index=1 is solar type
+        assert device_info.get("translation_key") == "solar"
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_empty_ems_list(self) -> None:
+        """Test handling of empty EMS list."""
+        data = HomevoltData.from_dict(
+            {
+                "aggregated": {
+                    "ems_data": {"state_str": "idle", "power": 0},
+                    "error_str": "",
+                    "bms_data": [],
+                },
+                "ems": [],
+                "sensors": [],
+            }
+        )
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, ems_index=0)
+
+        # Should return fallback
+        device_info = entity.device_info
+        assert device_info.get("identifiers") == {(DOMAIN, "ems_unknown_0")}
+
+    def test_empty_sensors_list(self) -> None:
+        """Test handling of empty sensors list."""
+        data = HomevoltData.from_dict(
+            {
+                "aggregated": {
+                    "ems_data": {"state_str": "idle", "power": 0},
+                    "error_str": "",
+                    "bms_data": [],
+                },
+                "ems": [],
+                "sensors": [],
+            }
+        )
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, sensor_index=0)
+
+        # Should return fallback
+        device_info = entity.device_info
+        assert device_info.get("identifiers") == {(DOMAIN, "sensor_unknown_0")}
+
+    def test_ems_with_no_bms_info(self) -> None:
+        """Test EMS device with missing BMS info."""
+        data = HomevoltData.from_dict(
+            {
+                "aggregated": {
+                    "ems_data": {"state_str": "idle", "power": 0},
+                    "error_str": "",
+                    "bms_data": [],
+                },
+                "ems": [
+                    {
+                        "ecu_id": "ecu_test",
+                        "ems_data": {"state_str": "idle", "power": 0},
+                        "error_str": "",
+                        "bms_data": [],
+                        "bms_info": [],  # Empty
+                    }
+                ],
+                "sensors": [],
+            }
+        )
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, ems_index=0, bms_index=0)
+
+        device_info = entity.device_info
+
+        # Should handle gracefully with fallback bms serial
+        assert "bms_ecu_test" in str(device_info.get("identifiers"))
+
+    def test_ems_with_missing_ecu_id(self) -> None:
+        """Test EMS device with missing ECU ID."""
+        data = HomevoltData.from_dict(
+            {
+                "aggregated": {
+                    "ems_data": {"state_str": "idle", "power": 0},
+                    "error_str": "",
+                    "bms_data": [],
+                },
+                "ems": [
+                    {
+                        "ecu_id": None,  # Missing
+                        "ems_data": {"state_str": "idle", "power": 0},
+                        "error_str": "",
+                    }
+                ],
+                "sensors": [],
+            }
+        )
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, ems_index=0)
+
+        device_info = entity.device_info
+
+        # Should use fallback ecu_id
+        assert device_info.get("identifiers") == {(DOMAIN, "ems_unknown_0")}
+
+    def test_sensor_with_missing_euid(self) -> None:
+        """Test sensor with missing EUID."""
+        data = HomevoltData.from_dict(
+            {
+                "aggregated": {
+                    "ems_data": {"state_str": "idle", "power": 0},
+                    "error_str": "",
+                    "bms_data": [],
+                },
+                "ems": [],
+                "sensors": [
+                    {
+                        "euid": None,  # Missing
+                        "type": "grid",
+                        "total_power": 100.0,
+                        "node_id": 0,
+                    }
+                ],
+            }
+        )
+        coordinator = create_mock_coordinator(data=data, main_device_id="test_123")
+        entity = HomevoltEntity(coordinator, sensor_index=0)
+
+        device_info = entity.device_info
+
+        # Should use "unknown" as euid
+        assert device_info.get("identifiers") == {(DOMAIN, "sensor_unknown")}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -62,14 +62,17 @@ async def test_sensor_energy_exported_entity_exists(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_api_client: MagicMock,
+    entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test energy exported sensor entity exists."""
+    """Test energy exported sensor entity exists but is disabled by default."""
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("sensor.system_energy_exported")
-    assert state is not None
-    assert state.attributes.get("device_class") == "energy"
-    assert state.attributes.get("unit_of_measurement") == UnitOfEnergy.KILO_WATT_HOUR
+    # This sensor is disabled by default, so check entity registry instead of state
+    entry = entity_registry.async_get("sensor.system_energy_exported")
+    assert entry is not None
+    assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    assert entry.original_device_class == "energy"
+    assert entry.unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
 
 
 async def test_sensor_entity_registry(


### PR DESCRIPTION
This pull request refactors the entity structure for the Homevolt Local integration, introducing a new `HomevoltEntity` base class to provide consistent device information and identification across all entity types. Sensor entities now inherit from this base class, simplifying device info logic and improving maintainability. Additionally, some sensor entity descriptions were updated for better registry management and diagnostics.

**Entity structure and device info refactor:**

* Added a new `entity.py` file with the `HomevoltEntity` base class and specialized subclasses for battery, inverter, and sensor device entities. This class centralizes device info logic and consistent identification for all Homevolt entities. (`custom_components/homevolt_local/entity.py`)
* Refactored `HomevoltSensor` to inherit from `HomevoltEntity` instead of `CoordinatorEntity`, removing redundant imports and attributes. (`custom_components/homevolt_local/sensor.py`) [[1]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943L27-L29) [[2]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943R42) [[3]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943L632-L635)

**Sensor entity description updates:**

* Added `entity_registry_enabled_default=False` to several sensor entity descriptions to prevent certain energy sensors from being enabled by default in the entity registry. (`custom_components/homevolt_local/sensor.py`) [[1]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943R306) [[2]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943R321) [[3]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943R397) [[4]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943R420) [[5]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943R487) [[6]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943R518) [[7]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943R593) [[8]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943R616)
* Removed `state_class=SensorStateClass.MEASUREMENT` from diagnostic sensor entity descriptions for grid and solar RSSI and packet delivery rate sensors, likely to better align with their intended usage. (`custom_components/homevolt_local/sensor.py`) [[1]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943L437) [[2]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943L451) [[3]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943L543) [[4]](diffhunk://#diff-76efd7559f13fa6643f8232975a3d6a38fe4b11cd2a5ff2d60618729e0661943L557)