### PR TITLE
fix: correct inverter energy charged/discharged mapping and multi-host aggregation (#104)

### DIFF
--- a/.github/skills/homeassistant-integration/SKILL.md
+++ b/.github/skills/homeassistant-integration/SKILL.md
@@ -187,6 +187,7 @@ def mock_config_entry() -> MockConfigEntry:
         unique_id="device_unique_id",
     )
 
+
 async def test_sensor_value(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/.github/skills/homevolt-api/SKILL.md
+++ b/.github/skills/homevolt-api/SKILL.md
@@ -58,8 +58,8 @@ The full API documentation is included in this skill folder:
 
 | Field | Location | Unit | Description |
 |-------|----------|------|-------------|
-| `ems_aggregate.imported_kwh` | Per EMS entry | kWh | Energy charged INTO battery |
-| `ems_aggregate.exported_kwh` | Per EMS entry | kWh | Energy discharged FROM battery |
+| `ems_aggregate.exported_kwh` | Per EMS entry | kWh | Energy charged INTO battery (inverter export to DC) |
+| `ems_aggregate.imported_kwh` | Per EMS entry | kWh | Energy discharged FROM battery (inverter import from DC) |
 
 **Important**: Use `ems_aggregate` values for battery energy - they match the Homevolt UI exactly.
 
@@ -162,19 +162,13 @@ Understanding the sign conventions is critical for correct sensor implementation
 
 ```python
 # For total system
-total_charged = sum(
-    ems.ems_aggregate.imported_kwh
-    for ems in data.ems
-)
-total_discharged = sum(
-    ems.ems_aggregate.exported_kwh
-    for ems in data.ems
-)
+total_charged = sum(ems.ems_aggregate.exported_kwh for ems in data.ems)
+total_discharged = sum(ems.ems_aggregate.imported_kwh for ems in data.ems)
 
 # Per EMS entry
 for ems in data.ems:
-    charged = ems.ems_aggregate.imported_kwh      # kWh
-    discharged = ems.ems_aggregate.exported_kwh   # kWh
+    charged = ems.ems_aggregate.exported_kwh  # kWh
+    discharged = ems.ems_aggregate.imported_kwh  # kWh
 ```
 
 ### Getting Grid/Solar/Load Power
@@ -182,6 +176,7 @@ for ems in data.ems:
 ```python
 def get_sensor_by_function(sensors: list, function: str):
     return next((s for s in sensors if s.function == function), None)
+
 
 grid = get_sensor_by_function(data.sensors, "grid")
 solar = get_sensor_by_function(data.sensors, "solar")

--- a/custom_components/homevolt_local/coordinator.py
+++ b/custom_components/homevolt_local/coordinator.py
@@ -17,11 +17,13 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import (
+    ATTR_AGGREGATED,
     ATTR_ECU_ID,
     ATTR_EMS,
     ATTR_EUID,
     ATTR_SENSORS,
     ATTR_TYPE,
+    BMS_DATA_INDEX_TOTAL,
     CONSOLE_RESOURCE_PATH,
     DEFAULT_CONNECT_TIMEOUT,
     DEFAULT_READ_TIMEOUT,
@@ -570,6 +572,62 @@ class HomevoltDataUpdateCoordinator(DataUpdateCoordinator[HomevoltData]):
         # Update the merged data with all EMS devices and sensors
         merged_data[ATTR_EMS] = all_ems
         merged_data[ATTR_SENSORS] = all_sensors
+
+        # If multiple EMS devices are present, aggregate their stats
+        # for the system-level aggregated device
+        if len(all_ems) > 1:
+            agg = dict(merged_data.get(ATTR_AGGREGATED, {}))
+            agg_ems_data = dict(agg.get("ems_data", {}))
+            agg_ems_info = dict(agg.get("ems_info", {}))
+            agg_ems_aggregate = dict(agg.get("ems_aggregate", {}))
+
+            agg_ems_data["energy_produced"] = sum(
+                e.get("ems_data", {}).get("energy_produced", 0) for e in all_ems
+            )
+            agg_ems_data["energy_consumed"] = sum(
+                e.get("ems_data", {}).get("energy_consumed", 0) for e in all_ems
+            )
+            agg_ems_data["power"] = sum(
+                e.get("ems_data", {}).get("power", 0) for e in all_ems
+            )
+
+            soc_values = [
+                e.get("ems_data", {}).get("soc_avg")
+                for e in all_ems
+                if e.get("ems_data", {}).get("soc_avg") is not None
+            ]
+            if soc_values:
+                agg_ems_data["soc_avg"] = sum(soc_values) / len(soc_values)
+
+            agg_ems_aggregate["imported_kwh"] = sum(
+                e.get("ems_aggregate", {}).get("imported_kwh", 0.0) for e in all_ems
+            )
+            agg_ems_aggregate["exported_kwh"] = sum(
+                e.get("ems_aggregate", {}).get("exported_kwh", 0.0) for e in all_ems
+            )
+
+            agg_ems_info["rated_capacity"] = sum(
+                e.get("ems_info", {}).get("rated_capacity", 0) for e in all_ems
+            )
+            agg_ems_info["rated_power"] = sum(
+                e.get("ems_info", {}).get("rated_power", 0) for e in all_ems
+            )
+
+            # Update aggregated BMS total SOC if present
+            agg_bms_data = list(agg.get("bms_data", []))
+            if agg_bms_data and len(agg_bms_data) > BMS_DATA_INDEX_TOTAL and soc_values:
+                bms_total = dict(agg_bms_data[BMS_DATA_INDEX_TOTAL])
+                avg_soc = sum(soc_values) / len(soc_values)
+                bms_total["soc"] = (
+                    int(avg_soc * 100) if avg_soc <= 100 else int(avg_soc)
+                )
+                agg_bms_data[BMS_DATA_INDEX_TOTAL] = bms_total
+                agg["bms_data"] = agg_bms_data
+
+            agg["ems_data"] = agg_ems_data
+            agg["ems_info"] = agg_ems_info
+            agg["ems_aggregate"] = agg_ems_aggregate
+            merged_data[ATTR_AGGREGATED] = agg
 
         if verbose_log:
             self.logger.debug(

--- a/custom_components/homevolt_local/sensor.py
+++ b/custom_components/homevolt_local/sensor.py
@@ -269,9 +269,9 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         translation_key="error",
         icon="mdi:battery-unknown",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.aggregated.error_str[:255]
-        if data.aggregated.error_str
-        else None,
+        value_fn=lambda data: (
+            data.aggregated.error_str[:255] if data.aggregated.error_str else None
+        ),
         attrs_fn=lambda data: {
             ATTR_ERROR_STR: data.aggregated.error_str,
         },
@@ -282,11 +282,12 @@ SENSOR_DESCRIPTIONS: tuple[HomevoltSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         icon_fn=_battery_icon_for_aggregated,
-        value_fn=lambda data: float(data.aggregated.bms_data[BMS_DATA_INDEX_TOTAL].soc)
-        / 100
-        if data.aggregated.bms_data
-        and len(data.aggregated.bms_data) > BMS_DATA_INDEX_TOTAL
-        else None,
+        value_fn=lambda data: (
+            float(data.aggregated.bms_data[BMS_DATA_INDEX_TOTAL].soc) / 100
+            if data.aggregated.bms_data
+            and len(data.aggregated.bms_data) > BMS_DATA_INDEX_TOTAL
+            else None
+        ),
     ),
     HomevoltSensorEntityDescription(
         key="power",
@@ -904,10 +905,9 @@ async def async_setup_entry(
                         device_class=SensorDeviceClass.TEMPERATURE,
                         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
                         state_class=SensorStateClass.MEASUREMENT,
-                        value_fn=lambda data, i=idx: float(
-                            data.ems[i].ems_data.sys_temp
-                        )
-                        / 10,
+                        value_fn=lambda data, i=idx: (
+                            float(data.ems[i].ems_data.sys_temp) / 10
+                        ),
                         icon="mdi:thermometer",
                         device_specific=True,
                     ),
@@ -924,8 +924,9 @@ async def async_setup_entry(
                         native_unit_of_measurement=PERCENTAGE,
                         state_class=SensorStateClass.MEASUREMENT,
                         icon_fn=lambda data, i=idx: _battery_icon_for_ems(data, i),
-                        value_fn=lambda data, i=idx: float(data.ems[i].ems_data.soc_avg)
-                        / 100,
+                        value_fn=lambda data, i=idx: (
+                            float(data.ems[i].ems_data.soc_avg) / 100
+                        ),
                         device_specific=True,
                     ),
                     ems_index=idx,
@@ -959,10 +960,10 @@ async def async_setup_entry(
                         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                         icon="mdi:battery-positive",
                         value_fn=lambda data, i=idx: _normalize_energy_val(
-                            data.ems[i].ems_aggregate.exported_kwh
+                            data.ems[i].ems_aggregate.imported_kwh
                         ),
                         raw_value_fn=lambda data, i=idx: _raw_energy_val(
-                            data.ems[i].ems_aggregate.exported_kwh
+                            data.ems[i].ems_aggregate.imported_kwh
                         ),
                         device_specific=True,
                     ),
@@ -981,10 +982,10 @@ async def async_setup_entry(
                         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                         icon="mdi:battery-negative",
                         value_fn=lambda data, i=idx: _normalize_energy_val(
-                            data.ems[i].ems_aggregate.imported_kwh
+                            data.ems[i].ems_aggregate.exported_kwh
                         ),
                         raw_value_fn=lambda data, i=idx: _raw_energy_val(
-                            data.ems[i].ems_aggregate.imported_kwh
+                            data.ems[i].ems_aggregate.exported_kwh
                         ),
                         device_specific=True,
                     ),
@@ -999,9 +1000,11 @@ async def async_setup_entry(
                         key=f"ems_{idx + 1}_error",
                         translation_key="error",
                         icon="mdi:battery-unknown",
-                        value_fn=lambda data, i=idx: data.ems[i].error_str[:255]
-                        if data.ems[i].error_str
-                        else None,
+                        value_fn=lambda data, i=idx: (
+                            data.ems[i].error_str[:255]
+                            if data.ems[i].error_str
+                            else None
+                        ),
                         attrs_fn=lambda data, i=idx: {
                             ATTR_ERROR_STR: data.ems[i].error_str,
                         },
@@ -1021,9 +1024,9 @@ async def async_setup_entry(
                         device_class=SensorDeviceClass.ENERGY_STORAGE,
                         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
                         icon="mdi:battery-plus",
-                        value_fn=lambda data, i=idx: data.ems[
-                            i
-                        ].ems_info.rated_capacity,
+                        value_fn=lambda data, i=idx: (
+                            data.ems[i].ems_info.rated_capacity
+                        ),
                         device_specific=True,
                     ),
                     ems_index=idx,
@@ -1056,9 +1059,9 @@ async def async_setup_entry(
                                 device_class=SensorDeviceClass.ENERGY_STORAGE,
                                 native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
                                 icon="mdi:battery-plus",
-                                value_fn=lambda data, i=idx, j=bms_idx: data.ems[i]
-                                .bms_info[j]
-                                .rated_cap,
+                                value_fn=lambda data, i=idx, j=bms_idx: (
+                                    data.ems[i].bms_info[j].rated_cap
+                                ),
                                 device_specific=True,
                             ),
                             ems_index=idx,
@@ -1076,10 +1079,9 @@ async def async_setup_entry(
                                 icon_fn=lambda data, i=idx, j=bms_idx: (
                                     _battery_icon_for_bms(data, i, j)
                                 ),
-                                value_fn=lambda data, i=idx, j=bms_idx: float(
-                                    data.ems[i].bms_data[j].soc
-                                )
-                                / 100,
+                                value_fn=lambda data, i=idx, j=bms_idx: (
+                                    float(data.ems[i].bms_data[j].soc) / 100
+                                ),
                                 device_specific=True,
                             ),
                             ems_index=idx,
@@ -1096,10 +1098,9 @@ async def async_setup_entry(
                                 device_class=SensorDeviceClass.TEMPERATURE,
                                 native_unit_of_measurement=UnitOfTemperature.CELSIUS,
                                 state_class=SensorStateClass.MEASUREMENT,
-                                value_fn=lambda data, i=idx, j=bms_idx: float(
-                                    data.ems[i].bms_data[j].tmax
-                                )
-                                / 10,
+                                value_fn=lambda data, i=idx, j=bms_idx: (
+                                    float(data.ems[i].bms_data[j].tmax) / 10
+                                ),
                                 icon="mdi:thermometer-chevron-up",
                                 device_specific=True,
                             ),
@@ -1117,10 +1118,9 @@ async def async_setup_entry(
                                 device_class=SensorDeviceClass.TEMPERATURE,
                                 native_unit_of_measurement=UnitOfTemperature.CELSIUS,
                                 state_class=SensorStateClass.MEASUREMENT,
-                                value_fn=lambda data, i=idx, j=bms_idx: float(
-                                    data.ems[i].bms_data[j].tmin
-                                )
-                                / 10,
+                                value_fn=lambda data, i=idx, j=bms_idx: (
+                                    float(data.ems[i].bms_data[j].tmin) / 10
+                                ),
                                 icon="mdi:thermometer-chevron-down",
                                 device_specific=True,
                             ),

--- a/tests/test_coordinator_merge.py
+++ b/tests/test_coordinator_merge.py
@@ -248,3 +248,111 @@ async def test_api_returns_duplicate_sensors(
         f"Expected 1 (duplicates filtered), got {solar_count}. "
         "Deduplication should remove duplicate sensors from the API response."
     )
+
+
+async def test_multi_host_aggregates_system_energy_and_power(
+    hass: HomeAssistant,
+) -> None:
+    """Test that energy and power from multiple hosts are combined in aggregated data."""
+    coordinator = HomevoltDataUpdateCoordinator(
+        hass=hass,
+        logger=logging.getLogger(__name__),
+        entry_id="test_entry",
+        resources=[
+            "http://192.168.1.100/ems.json",
+            "http://192.168.1.101/ems.json",
+        ],
+        hosts=["http://192.168.1.100", "http://192.168.1.101"],
+        main_host="http://192.168.1.100",
+        ecu_id=None,
+        username=None,
+        password=None,
+        verify_ssl=False,
+        update_interval=timedelta(seconds=30),
+    )
+
+    host1_response = {
+        "aggregated": {
+            "ems_data": {
+                "state_str": "charging",
+                "soc_avg": 40.0,
+                "power": 1500.0,
+                "energy_produced": 2000.0,
+                "energy_consumed": 3000.0,
+            },
+            "ems_aggregate": {"imported_kwh": 50.0, "exported_kwh": 100.0},
+            "ems_info": {"rated_capacity": 6000, "rated_power": 3000},
+            "error_str": "",
+            "bms_data": [{"soc": 4000}, {"soc": 4000}],
+        },
+        "ems": [
+            {
+                "ecu_id": "ecu_host_1",
+                "ems_data": {
+                    "state_str": "charging",
+                    "soc_avg": 40.0,
+                    "power": 1500.0,
+                    "energy_produced": 2000.0,
+                    "energy_consumed": 3000.0,
+                },
+                "ems_aggregate": {"imported_kwh": 50.0, "exported_kwh": 100.0},
+                "ems_info": {"rated_capacity": 6000, "rated_power": 3000},
+                "error_str": "",
+                "bms_data": [{"soc": 4000}],
+            }
+        ],
+        "sensors": [],
+    }
+
+    host2_response = {
+        "aggregated": {
+            "ems_data": {
+                "state_str": "charging",
+                "soc_avg": 60.0,
+                "power": 1200.0,
+                "energy_produced": 1000.0,
+                "energy_consumed": 1500.0,
+            },
+            "ems_aggregate": {"imported_kwh": 30.0, "exported_kwh": 70.0},
+            "ems_info": {"rated_capacity": 6000, "rated_power": 3000},
+            "error_str": "",
+            "bms_data": [{"soc": 6000}, {"soc": 6000}],
+        },
+        "ems": [
+            {
+                "ecu_id": "ecu_host_2",
+                "ems_data": {
+                    "state_str": "charging",
+                    "soc_avg": 60.0,
+                    "power": 1200.0,
+                    "energy_produced": 1000.0,
+                    "energy_consumed": 1500.0,
+                },
+                "ems_aggregate": {"imported_kwh": 30.0, "exported_kwh": 70.0},
+                "ems_info": {"rated_capacity": 6000, "rated_power": 3000},
+                "error_str": "",
+                "bms_data": [{"soc": 6000}],
+            }
+        ],
+        "sensors": [],
+    }
+
+    async def mock_fetch(resource: str) -> dict[str, Any]:
+        if "192.168.1.100" in resource:
+            return host1_response
+        return host2_response
+
+    with patch.object(coordinator, "_fetch_resource_data", side_effect=mock_fetch):
+        with patch.object(coordinator, "_fetch_schedule_data", return_value={}):
+            data = await coordinator._async_update_data()
+
+    assert len(data.ems) == 2
+    # Verify combined system-level energy and power
+    assert data.aggregated.ems_data.energy_produced == 3000.0
+    assert data.aggregated.ems_data.energy_consumed == 4500.0
+    assert data.aggregated.ems_data.power == 2700.0
+    assert data.aggregated.ems_data.soc_avg == 50.0
+    assert data.aggregated.ems_aggregate.imported_kwh == 80.0
+    assert data.aggregated.ems_aggregate.exported_kwh == 170.0
+    assert data.aggregated.ems_info.rated_capacity == 12000
+    assert data.aggregated.ems_info.rated_power == 6000

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -10,6 +10,9 @@ from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from syrupy.assertion import SnapshotAssertion
 
+from custom_components.homevolt_local.models import HomevoltData
+from custom_components.homevolt_local.sensor import _normalize_energy_val
+
 from .conftest import setup_integration
 
 
@@ -134,3 +137,29 @@ async def test_sensor_states_snapshot(
             }
 
     assert states == snapshot
+
+
+async def test_inverter_energy_charged_discharged_mapping() -> None:
+    """Test inverter energy charged and discharged sensors map correctly to ems_aggregate."""
+    raw_data = {
+        "aggregated": {
+            "ems_data": {"state_str": "idle", "power": 0},
+            "ems_aggregate": {"imported_kwh": 100.0, "exported_kwh": 200.0},
+        },
+        "ems": [
+            {
+                "ecu_id": "test_ecu_123",
+                "ems_data": {"state_str": "idle", "power": 0},
+                "ems_aggregate": {"imported_kwh": 350.5, "exported_kwh": 780.2},
+                "inv_info": {"serial_number": "INV001"},
+            }
+        ],
+        "sensors": [],
+    }
+    data = HomevoltData.from_dict(raw_data)
+
+    # Inverter charged sensor should use exported_kwh (energy exported into battery)
+    assert _normalize_energy_val(data.ems[0].ems_aggregate.exported_kwh) == 780.2
+
+    # Inverter discharged sensor should use imported_kwh (energy imported from battery)
+    assert _normalize_energy_val(data.ems[0].ems_aggregate.imported_kwh) == 350.5


### PR DESCRIPTION
## Description

Resolves #104.

### Problem
1. **Inverter Charged / Discharged Values Swapped**: In `sensor.py`, `ems_energy_discharged` was mapped to `ems_aggregate.exported_kwh` and `ems_energy_charged` was mapped to `ems_aggregate.imported_kwh`. In the ECU's power stage, exporting DC power from the inverter charges the battery, while importing DC power discharges the battery. This caused `energy_discharged` to increment when the battery was charging.
2. **Aggregated System Values Omitted Multi-Host Devices**: In `coordinator.py` (`_merge_data`), when multiple hosts were configured, `merged_data["aggregated"]`, `energy_produced`, `energy_consumed`, `power`, `imported_kwh`, and `exported_kwh` only contained data from the primary host (Inverter 1), omitting Inverter 2 and subsequent units.

### Solution
1. Swapped the mapping in `custom_components/homevolt_local/sensor.py`:
   - `ems_{idx + 1}_energy_charged` -> `data.ems[i].ems_aggregate.exported_kwh`
   - `ems_{idx + 1}_energy_discharged` -> `data.ems[i].ems_aggregate.imported_kwh`
2. Added multi-device aggregation in `coordinator.py` (`_merge_data`):
   - Dynamically sums `energy_produced`, `energy_consumed`, `power`, `imported_kwh`, `exported_kwh`, `rated_capacity`, and `rated_power` across all EMS devices when multiple EMS units are present.
   - Computes weighted/average battery state of charge for system-level total SOC.
3. Updated documentation in `.github/skills/homevolt-api/SKILL.md`.
4. Added unit tests in `tests/test_coordinator_merge.py` and `tests/test_sensor.py`.